### PR TITLE
Update setup-nginx.sh

### DIFF
--- a/setup-nginx.sh
+++ b/setup-nginx.sh
@@ -8,4 +8,4 @@ apt -y install nginx
 rm /var/www/html/index.nginx-debian.html
 
 # Create the default page for the region
-wget https://raw.githubusercontent.com/MicrosoftDocs/mslearn-distribute-load-with-traffic-manager/module-update/index.$1.html -O /var/www/html/index.html
+wget https://raw.githubusercontent.com/MicrosoftDocs/mslearn-distribute-load-with-traffic-manager/master/index.$1.html -O /var/www/html/index.html


### PR DESCRIPTION
Deployments are failing for this unit: https://docs.microsoft.com/en-us/learn/modules/distribute-load-with-traffic-manager/3-exercise-priority-routing

The following error is being thrown:

```
kithinjiduane@Azure:~$ az group deployment create \
>     --resource-group learn-c0859d35-1dc3-4d60-a67f-8af330103878 \
>     --template-uri  https://raw.githubusercontent.com/MicrosoftDocs/mslearn-distribute-load-with-traffic-manager/master/azuredeploy.json \
>     --parameters password="$(head /dev/urandom | tr -dc A-Za-z0-9 | head -c 32)"
Deployment failed. Correlation ID: 1e6da856-f7e7-4ff5-8846-9bab494598d5. {
  "status": "Failed",
  "error": {
    "code": "ResourceDeploymentFailure",
    "message": "The resource operation completed with terminal provisioning state 'Failed'.",
    "details": [
      {
        "code": "VMExtensionProvisioningError",
        "message": "VM has reported a failure when processing extension 'apache-ext'. Error message: \"Enable failed: failed to execute command: command terminated with exit status=8\n[stdout]\n0ubuntu2_amd64.deb ...\r\nUnpacking libfontconfig1:amd64 (2.12.6-0ubuntu2) ...\r\nSelecting previously unselected package libjpeg8:amd64.\r\nPreparing to unpack .../04-libjpeg8_8c-2ubuntu8_amd64.deb ...\r\nUnpacking libjpeg8:amd64 (8c-2ubuntu8) ...\r\nSelecting previously unselected package libjbig0:amd64.\r\nPreparing to unpack .../05-libjbig0_2.1-3.1build1_amd64.deb ...\r\nUnpacking libjbig0:amd64 (2.1-3.1build1) ...\r\nSelecting previously unselected package libtiff5:amd64.\r\nPreparing to unpack .../06-libtiff5_4.0.9-5ubuntu0.3_amd64.deb ...\r\nUnpacking libtiff5:amd64 (4.0.9-5ubuntu0.3) ...\r\nSelecting previously unselected package libwebp6:amd64.\r\nPreparing to unpack .../07-libwebp6_0.6.1-2_amd64.deb ...\r\nUnpacking libwebp6:amd64 (0.6.1-2) ...\r\nSelecting previously unselected package libxpm4:amd64.\r\nPreparing to unpack .../08-libxpm4_1%3a3.5.12-1_amd64.deb ...\r\nUnpacking libxpm4:amd64 (1:3.5.12-1) ...\r\nSelecting previously unselected package libgd3:amd64.\r\nPreparing to unpack .../09-libgd3_2.2.5-4ubuntu0.3_amd64.deb ...\r\nUnpacking libgd3:amd64 (2.2.5-4ubuntu0.3) ...\r\nSelecting previously unselected package nginx-common.\r\nPreparing to unpack .../10-nginx-common_1.14.0-0ubuntu1.7_all.deb ...\r\nUnpacking nginx-common (1.14.0-0ubuntu1.7) ...\r\nSelecting previously unselected package libnginx-mod-http-geoip.\r\nPreparing to unpack .../11-libnginx-mod-http-geoip_1.14.0-0ubuntu1.7_amd64.deb ...\r\nUnpacking libnginx-mod-http-geoip (1.14.0-0ubuntu1.7) ...\r\nSelecting previously unselected package libnginx-mod-http-image-filter.\r\nPreparing to unpack .../12-libnginx-mod-http-image-filter_1.14.0-0ubuntu1.7_amd64.deb ...\r\nUnpacking libnginx-mod-http-image-filter (1.14.0-0ubuntu1.7) ...\r\nSelecting previously unselected package libnginx-mod-http-xslt-filter.\r\nPreparing to unpack .../13-libnginx-mod-http-xslt-filter_1.14.0-0ubuntu1.7_amd64.deb ...\r\nUnpacking libnginx-mod-http-xslt-filter (1.14.0-0ubuntu1.7) ...\r\nSelecting previously unselected package libnginx-mod-mail.\r\nPreparing to unpack .../14-libnginx-mod-mail_1.14.0-0ubuntu1.7_amd64.deb ...\r\nUnpacking libnginx-mod-mail (1.14.0-0ubuntu1.7) ...\r\nSelecting previously unselected package libnginx-mod-stream.\r\nPreparing to unpack .../15-libnginx-mod-stream_1.14.0-0ubuntu1.7_amd64.deb ...\r\nUnpacking libnginx-mod-stream (1.14.0-0ubuntu1.7) ...\r\nSelecting previously unselected package nginx-core.\r\nPreparing to unpack .../16-nginx-core_1.14.0-0ubuntu1.7_amd64.deb ...\r\nUnpacking nginx-core (1.14.0-0ubuntu1.7) ...\r\nSelecting previously unselected package nginx.\r\nPreparing to unpack .../17-nginx_1.14.0-0ubuntu1.7_all.deb...\r\nUnpacking nginx (1.14.0-0ubuntu1.7) ...\r\nSetting up libjbig0:amd64 (2.1-3.1build1) ...\r\nSetting up fonts-dejavu-core (2.37-1) ...\r\nSetting up nginx-common (1.14.0-0ubuntu1.7) ...\r\ndebconf: unable to initialize frontend: Dialog\r\ndebconf: (TERM is not set, so the dialog frontend is not usable.)\r\ndebconf: falling back to frontend: Readline\r\nCreated symlink /etc/systemd/system/multi-user.target.wants/nginx.service → /lib/systemd/system/nginx.service.\r\nSetting up libjpeg-turbo8:amd64 (1.5.2-0ubuntu5.18.04.3) ...\r\nSetting up libnginx-mod-mail (1.14.0-0ubuntu1.7) ...\r\nSetting up libxpm4:amd64(1:3.5.12-1) ...\r\nSetting up libnginx-mod-http-xslt-filter (1.14.0-0ubuntu1.7) ...\r\nSetting up libnginx-mod-http-geoip (1.14.0-0ubuntu1.7) ...\r\nSetting up libwebp6:amd64 (0.6.1-2) ...\r\nSetting up libjpeg8:amd64 (8c-2ubuntu8) ...\r\nSettingup fontconfig-config (2.12.6-0ubuntu2) ...\r\nSetting up libnginx-mod-stream (1.14.0-0ubuntu1.7) ...\r\nSetting up libtiff5:amd64 (4.0.9-5ubuntu0.3) ...\r\nSetting up libfontconfig1:amd64 (2.12.6-0ubuntu2) ...\r\nSetting up libgd3:amd64 (2.2.5-4ubuntu0.3) ...\r\nSetting up libnginx-mod-http-image-filter (1.14.0-0ubuntu1.7) ...\r\nSetting up nginx-core (1.14.0-0ubuntu1.7) ...\r\nSetting up nginx (1.14.0-0ubuntu1.7) ...\r\nProcessing triggers for systemd (237-3ubuntu10.38) ...\r\nProcessing triggers for man-db (2.8.3-2ubuntu0.1) ...\r\nProcessing triggers for ufw (0.36-0ubuntu0.18.04.1) ...\r\nProcessing triggers for ureadahead (0.100.0-21) ...\r\nProcessing triggers for libc-bin (2.27-3ubuntu1) ...\r\n\n[stderr]\n\nWARNING: apt does not have a stable CLI interface. Use with caution in scripts.\n\ndebconf: unable to initialize frontend: Dialog\ndebconf: (TERM is not set, so the dialog frontend is not usable.)\ndebconf: falling back to frontend: Readline\ndebconf: unable to initialize frontend: Readline\ndebconf: (This frontend requires a controlling tty.)\ndebconf: falling back to frontend: Teletype\ndpkg-preconfigure: unable to re-open stdin: \n--2020-02-14 14:02:28--  https://raw.githubusercontent.com/MicrosoftDocs/mslearn-distribute-load-with-traffic-manager/module-update/index.westus2.html\nResolving raw.githubusercontent.com (raw.githubusercontent.com)... 151.101.52.133\nConnecting to raw.githubusercontent.com (raw.githubusercontent.com)|151.101.52.133|:443...connected.\nHTTP request sent, awaiting response... 404 Not Found\n2020-02-14 14:02:28 ERROR 404: Not Found.\n\n\"\r\n\r\nMore information on troubleshooting is available at https://aka.ms/VMExtensionCSELinuxTroubleshoot "
      }
    ]
  }
}
```

When you try to access the url: https://raw.githubusercontent.com/MicrosoftDocs/mslearn-distribute-load-with-traffic-manager/module-update/index.westus2.html directly, you get 404: Not Found.

Please update to allow students to complete course work successfully.